### PR TITLE
Bugfix - fix az webapp show errors

### DIFF
--- a/src/appservice-kube/azext_appservice_kube/custom.py
+++ b/src/appservice-kube/azext_appservice_kube/custom.py
@@ -1140,6 +1140,10 @@ def list_publish_profiles(cmd, resource_group_name, name, slot=None):
 
     profiles = xmltodict.parse(full_xml, xml_attribs=True)['publishData']['publishProfile']
     converted = []
+
+    if type(profiles) is not list:
+        profiles = [profiles]
+
     for profile in profiles:
         new = {}
         for key in profile:
@@ -1538,8 +1542,9 @@ def _check_zip_deployment_status(cmd, rg_name, name, deployment_status_url, auth
 
 def _fill_ftp_publishing_url(cmd, webapp, resource_group_name, name, slot=None):
     profiles = list_publish_profiles(cmd, resource_group_name, name, slot)
-    url = next(p['publishUrl'] for p in profiles if p['publishMethod'] == 'FTP')
-    setattr(webapp, 'ftpPublishingUrl', url)
+    url = next((p['publishUrl'] for p in profiles if p['publishMethod'] == 'FTP'), None)
+    if url:
+        setattr(webapp, 'ftpPublishingUrl', url)
     return webapp
 
 def _get_url(cmd, resource_group_name, name, slot=None):


### PR DESCRIPTION
---
Copied over from task:

Relevant CLI methods are _fill_ftp_publishing_url and list_publish_profiles

Problem is that kubeapps only have one publishing profile. The return value from the API is structured exactly the same as for regular app service, but there is only one publishProfile entry, and the list_publish_profiles method assumes there will be more than one and treats the parsed object as a list by default.

Additionally _fill_ftp_publishing_url assumes that there will be one entry in this list where publishMethod == 'FTP', but we do not support FTP, so this method needs to handle that.

These methods were copied over from the main CLI originally, but are a part of the appservice-kube extension, so the versions in the main CLI are not executed.


This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
